### PR TITLE
Fix for "Command with the same number is already expected"

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -67,8 +67,15 @@ function execute(proc, command, commandNumber, args, noSplitArgs, encoding) {
         .forEach(arg => writeStdIn(proc, arg, encoding))
 }
 
+var previous = 0;
 function genCommandNumber() {
-    return String(Math.floor(Math.random() * 1000000))
+    var date = Date.now();
+    if (date <= previous) {
+        date = ++previous;
+    } else {
+        previous = date;
+    }
+    return String(date);
 }
 
 function executeCommand(proc, stdoutRws, stderrRws, command, args, noSplitArgs, encoding) {


### PR DESCRIPTION
When starting a large number of commands (>2000), the same command number is sometimes generated twice. This fixes the error by providing a real unique number for each command