### PR TITLE
only throw warning if perl locale is missing

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -168,6 +168,8 @@ function spawn(bin, options) {
             // listening for echo2 in stderr (echo and echo1 won't work)
             if (d === echoString) {
                 resolve(proc)
+            } else if (d.includes("perl: warning: Setting locale failed.")) {
+                console.warn(d);
             } else {
                 reject(new Error(`Unexpected string on start: ${d}`))
             }

--- a/src/lib.js
+++ b/src/lib.js
@@ -167,8 +167,9 @@ function spawn(bin, options) {
             const d = data.toString().trim()
             // listening for echo2 in stderr (echo and echo1 won't work)
             if (d === echoString) {
-                resolve(proc)
+                resolve(proc);
             } else if (d.includes("perl: warning: Setting locale failed.")) {
+                resolve(proc);
                 console.warn(d);
             } else {
                 reject(new Error(`Unexpected string on start: ${d}`))


### PR DESCRIPTION
i am using your tool with electron and it terminates with the error:
```sh
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = "en-US",
	LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to a fallback locale ("en_US.UTF-8").
```
using it without electron doesn't throw an error on the same system.
this logs the error as warning but won't exit.